### PR TITLE
Include pending IPs when evaluating need for new IPs

### DIFF
--- a/pkg/floatingip/ip_controller.go
+++ b/pkg/floatingip/ip_controller.go
@@ -265,7 +265,7 @@ func (i *ipController) reconcileDesiredIPs(ctx context.Context) {
 		return
 	}
 	// Acquire new IPs if needed. If this fails, we can try again next reconcile.
-	for j := len(i.ips); j < i.desiredIPs; j++ {
+	for j := len(i.ips) + len(i.pendingIPs); j < i.desiredIPs; j++ {
 		i.log.Info("requesting ip from provider")
 		i.updateStatus = true
 		ip, err := i.provider.CreateIP(ctx, i.region)

--- a/pkg/floatingip/ip_controller_test.go
+++ b/pkg/floatingip/ip_controller_test.go
@@ -26,6 +26,7 @@ func TestIPControllerReconcileDesiredIPs(t *testing.T) {
 		name             string
 		desiredIPs       int
 		existingIPs      []string
+		pendingIPs       []string
 		region           string
 		responses        []createIPRes
 		expectPendingIPs []string
@@ -36,6 +37,14 @@ func TestIPControllerReconcileDesiredIPs(t *testing.T) {
 			desiredIPs:       3,
 			existingIPs:      []string{"192.168.1.1"},
 			responses:        []createIPRes{{ip: "192.168.1.2", region: "earth"}, {ip: "192.168.1.3", region: "earth"}},
+			expectPendingIPs: []string{"192.168.1.2", "192.168.1.3"},
+		},
+		{
+			name:             "already have pending ips",
+			desiredIPs:       3,
+			existingIPs:      []string{"192.168.1.1"},
+			pendingIPs:       []string{"192.168.1.2", "192.168.1.3"},
+			responses:        []createIPRes{},
 			expectPendingIPs: []string{"192.168.1.2", "192.168.1.3"},
 		},
 		{
@@ -53,6 +62,7 @@ func TestIPControllerReconcileDesiredIPs(t *testing.T) {
 			i := &ipController{
 				desiredIPs: tc.desiredIPs,
 				ips:        tc.existingIPs,
+				pendingIPs: tc.pendingIPs,
 				region:     tc.region,
 				provider: &provider.MockProvider{
 					CreateIPFunc: func(_ context.Context, region string) (string, error) {


### PR DESCRIPTION
IPs stay in the pending state until they are persisted back to the Kubernetes record. If we fail to persist, we hold the allocations in memory and retry the write to Kubernetes. Before this PR the `reconcileDesiredIPs` only considered the persisted IPs, ignoring these pending IPs and allocating more (which end up in the pending state).  

This combined with the insufficient RBAC privileges for the flipopservice account (fixed in #6) caused a loop of floating IP allocation until the users limit was met.