### PR TITLE
Optional cool-down period after floating-ip assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ spec:
   provider: digitalocean
   region: nyc3
   desiredIPs: 3
+  assignmentCoolOffSeconds: 20
   ips:
   - 192.168.1.1
   - 192.168.2.1

--- a/examples/floatingippool.yaml
+++ b/examples/floatingippool.yaml
@@ -13,6 +13,7 @@ spec:
     recordName: hello-world
     zone: example.com
     ttl: 120
+  assignmentCoolOffSeconds: 20
   match:
     podNamespace: ingress
     podLabel: app=nginx-ingress,component=controller

--- a/k8s/flipop.floatingippool.crd.yaml
+++ b/k8s/flipop.floatingippool.crd.yaml
@@ -66,6 +66,9 @@ spec:
                       type: string
                     ttl:
                       type: integer
+                assignmentCoolOffSeconds:
+                  type: number
+                  minimum: 0
             status:
               type: object
               properties:

--- a/pkg/apis/flipop/generated/clientset/versioned/clientset.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/clientset.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/doc.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/fake/clientset_generated.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/fake/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/fake/doc.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/fake/register.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/fake/register.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/scheme/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/scheme/doc.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/scheme/register.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/scheme/register.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/doc.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/doc.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_flipop_client.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_flipop_client.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_floatingippool.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_floatingippool.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_nodednsrecordset.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_nodednsrecordset.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/flipop_client.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/flipop_client.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/floatingippool.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/floatingippool.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/generated_expansion.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/generated_expansion.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/nodednsrecordset.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/nodednsrecordset.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/informers/externalversions/factory.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/factory.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/informers/externalversions/flipop/interface.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/flipop/interface.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/floatingippool.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/floatingippool.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/interface.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/interface.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/nodednsrecordset.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/nodednsrecordset.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/informers/externalversions/generic.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/generic.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/listers/flipop/v1alpha1/expansion_generated.go
+++ b/pkg/apis/flipop/generated/listers/flipop/v1alpha1/expansion_generated.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/listers/flipop/v1alpha1/floatingippool.go
+++ b/pkg/apis/flipop/generated/listers/flipop/v1alpha1/floatingippool.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/generated/listers/flipop/v1alpha1/nodednsrecordset.go
+++ b/pkg/apis/flipop/generated/listers/flipop/v1alpha1/nodednsrecordset.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/apis/flipop/v1alpha1/flipop_types.go
+++ b/pkg/apis/flipop/v1alpha1/flipop_types.go
@@ -58,6 +58,10 @@ type FloatingIPPoolSpec struct {
 
 	// DNS describes a DNS record which should point to the floating IPs.
 	DNSRecordSet *DNSRecordSet `json:"dnsRecordSet,omitempty"`
+
+	// AssignmentCoolOffSeconds sets a delay between IP assignments. This functionality can be used
+	// to prevent rapid reshuffling and reduces the chances/impact of concurrent assignments.
+	AssignmentCoolOffSeconds float64 `json:"assignmentCoolOffSeconds,omitempty"`
 }
 
 // Match describes a pattern for finding resources the floating-IP should follow.

--- a/pkg/apis/flipop/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/flipop/v1alpha1/zz_generated.deepcopy.go
@@ -3,7 +3,7 @@
 /*
 MIT License
 
-Copyright (c) 2020 Digital Ocean, Inc.
+Copyright (c) 2021 Digital Ocean, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/floatingip/floatingippool_controller.go
+++ b/pkg/floatingip/floatingippool_controller.go
@@ -193,7 +193,8 @@ func (c *Controller) updateOrAdd(k8sPool *flipopv1alpha1.FloatingIPPool) {
 	if k8sPool.Spec.DNSRecordSet != nil && k8sPool.Spec.DNSRecordSet.Provider != "" {
 		dnsProv, _ = c.providers[k8sPool.Spec.DNSRecordSet.Provider].(provider.DNSProvider)
 	}
-	ipChange := pool.ipController.updateProviders(prov, dnsProv, k8sPool.Spec.Region)
+	coolOff := time.Duration(k8sPool.Spec.AssignmentCoolOffSeconds * float64(time.Second))
+	ipChange := pool.ipController.updateProviders(prov, dnsProv, k8sPool.Spec.Region, coolOff)
 	pool.ipController.updateIPs(k8sPool.Spec.IPs, k8sPool.Spec.DesiredIPs)
 	pool.ipController.updateDNSSpec(k8sPool.Spec.DNSRecordSet)
 	if ipChange {

--- a/pkg/floatingip/floatingippool_controller_test.go
+++ b/pkg/floatingip/floatingippool_controller_test.go
@@ -196,6 +196,7 @@ func TestFloatingIPPoolUpdateK8s(t *testing.T) {
 			manip: func(f *flipopv1alpha1.FloatingIPPool, c *Controller) {
 				f.Spec.Match.PodNamespace = ""
 				f.Spec.Match.PodLabel = ""
+				f.Spec.AssignmentCoolOffSeconds = 1.0
 			},
 			expectIPAssignment: map[string]string{
 				// It's non-deterministic if rio-grande or rubicon will get 192.168.1.1, but


### PR DESCRIPTION
This PR provides configuration for a cool-down period between IP assignments.  This should be useful in preventing rapid shuffling of IP address assignments when multiple nodes experience issue.  This should provide more stability, and also can be used to mitigate a rare bug in DigitalOcean's floating IP implementation caused by quickly pivoting a droplet from one floating-IP to another.