### PR TITLE
APPS-4606: add NodeDNSRecordSetStatus State

### DIFF
--- a/pkg/apis/flipop/generated/clientset/versioned/clientset.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/clientset.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/doc.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/fake/clientset_generated.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/fake/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/fake/doc.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/fake/register.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/fake/register.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/scheme/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/scheme/doc.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/scheme/register.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/scheme/register.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/doc.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/doc.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/doc.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_flipop_client.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_flipop_client.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_floatingippool.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_floatingippool.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_nodednsrecordset.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/fake/fake_nodednsrecordset.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/flipop_client.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/flipop_client.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/floatingippool.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/floatingippool.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/generated_expansion.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/generated_expansion.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/nodednsrecordset.go
+++ b/pkg/apis/flipop/generated/clientset/versioned/typed/flipop/v1alpha1/nodednsrecordset.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/informers/externalversions/factory.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/factory.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/informers/externalversions/flipop/interface.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/flipop/interface.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/floatingippool.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/floatingippool.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/interface.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/interface.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/nodednsrecordset.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/flipop/v1alpha1/nodednsrecordset.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/informers/externalversions/generic.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/generic.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/apis/flipop/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/listers/flipop/v1alpha1/expansion_generated.go
+++ b/pkg/apis/flipop/generated/listers/flipop/v1alpha1/expansion_generated.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/listers/flipop/v1alpha1/floatingippool.go
+++ b/pkg/apis/flipop/generated/listers/flipop/v1alpha1/floatingippool.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/generated/listers/flipop/v1alpha1/nodednsrecordset.go
+++ b/pkg/apis/flipop/generated/listers/flipop/v1alpha1/nodednsrecordset.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/flipop/v1alpha1/flipop_types.go
+++ b/pkg/apis/flipop/v1alpha1/flipop_types.go
@@ -36,6 +36,15 @@ const (
 	IPStateDisabled IPState = "disabled"
 )
 
+const (
+	// NodeDNSRecordActive indicates that the DNS record has been created.
+	NodeDNSRecordActive NodeDNSRecordState = "active"
+	// NodeDNSRecordInProgress indicates an DNS record action in progress.
+	NodeDNSRecordInProgress NodeDNSRecordState = "in-progress"
+	// NodeDNSRecordError indicates the last  DNS record action failed.
+	NodeDNSRecordError NodeDNSRecordState = "error"
+)
+
 // FloatingIPPoolSpec defines the desired state of FloatingIPPool.
 type FloatingIPPoolSpec struct {
 	// IPs is a list of floating IP addresses for assignment. IPs may be omitted or incomplete if
@@ -93,6 +102,9 @@ type FloatingIPPoolStatus struct {
 
 // IPState describes the condition of an IP.
 type IPState string
+
+// NodeDNSRecordState describes the condition of a NodeDNSRecordSet.
+type NodeDNSRecordState string
 
 // IPStatus describes the mapping between IPs and the matching
 // resources responsible for their attachment.
@@ -161,7 +173,8 @@ type NodeDNSRecordSetList struct {
 
 // NodeDNSRecordSetStatus defines the observed state of NodeDNSRecordSet.
 type NodeDNSRecordSetStatus struct {
-	Error string `json:"error,omitempty"`
+	Error string             `json:"error,omitempty"`
+	State NodeDNSRecordState `json:"state"`
 }
 
 // NodeDNSRecordSetSpec defines the desired state of NodeDNSRecordSet.

--- a/pkg/apis/flipop/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/flipop/v1alpha1/zz_generated.deepcopy.go
@@ -2,7 +2,7 @@
 
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2021 Digital Ocean, Inc.
+// Copyright 2022 Digital Ocean, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -137,7 +137,7 @@ func (r *Registry) Collect(ch chan<- prometheus.Metric) {
 	r.metrics.callsTotal.Collect(ch)
 }
 
-// Collect implements prometheus.Collector
+// Describe implements prometheus.Collector
 func (r *Registry) Describe(ch chan<- *prometheus.Desc) {
 	r.metrics.callLatency.Describe(ch)
 	r.metrics.callsTotal.Describe(ch)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,4 @@
 package version
 
+// Version is the version of the package.
 var Version string = "dev"


### PR DESCRIPTION
Adds `State` property to `NodeDNSRecordSetStatus` to help keep track of the state of the DNS reconcile progress.