### PR TITLE
APPS-4945: add option to keep last DNS record 

### DIFF
--- a/cmd/flipop/main.go
+++ b/cmd/flipop/main.go
@@ -47,6 +47,7 @@ const (
 )
 
 var debug bool
+var keepLastRecord bool
 var ctx context.Context
 var log logrus.FieldLogger
 
@@ -80,6 +81,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "debug logging")
 	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "path to kubeconfig file")
 	rootCmd.Flags().StringVar(&healthBindAddr, "metrics-bind-addr", ":8080", "bind addr for metrics server, set empty string to disable")
+	rootCmd.Flags().BoolVar(&keepLastRecord, "keep-last-record", false, "to avoid NXDomain, keep the last DNS record for a record name even if unhealthy")
 	rootCmd.Execute()
 }
 
@@ -114,7 +116,10 @@ func runMain(cmd *cobra.Command, args []string) {
 	}
 	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
 
-	providers := provider.NewRegistry(provider.WithLogger(log))
+	providers := provider.NewRegistry(
+		provider.WithLogger(log),
+		provider.WithKeepLastDNSRecord(keepLastRecord),
+	)
 	if err := providers.Init(); err != nil {
 		fmt.Fprintln(os.Stdout, err.Error())
 		os.Exit(1)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -87,9 +87,10 @@ type DNSProvider interface {
 
 // Registry holds active providers and the material to initialize them.
 type Registry struct {
-	providers map[string]BaseProvider
-	metrics   *metrics
-	log       logrus.FieldLogger
+	providers      map[string]BaseProvider
+	metrics        *metrics
+	log            logrus.FieldLogger
+	keepLastRecord bool
 }
 
 // NewRegistry creates a new registry with the provided options.
@@ -150,6 +151,17 @@ type RegistryOption func(*Registry)
 func WithLogger(log logrus.FieldLogger) RegistryOption {
 	return func(r *Registry) {
 		r.log = log
+	}
+}
+
+// WithKeepLastDNSRecord sets the flag for keeping the last DNS record for a record name.
+// If all records for a record name are deleted we could get NXDOMAIN with possibly a very long TTL.
+// This may be undesireable.
+// Setting this flag to true will attempt to keep the last DNS record even though it may
+// point to an unhealthy IP.
+func WithKeepLastDNSRecord(v bool) RegistryOption {
+	return func(r *Registry) {
+		r.keepLastRecord = v
 	}
 }
 


### PR DESCRIPTION
Adds `WithKeepLastDNSRecord` provider option.  If all records for a record name are deleted we could get `NXDOMAIN` with possibly a very long TTL. This may be undesirable. Setting this flag to true will attempt to keep the last DNS record even though it may point to an unhealthy IP, in order to avoid `NXDOMAIN` state.