### PR TITLE
fix apiVersion in rbac definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.out
 
 .vscode
+.idea
 
 # Exclude binary
 /flipop

--- a/k8s/flipop.floatingippool.crd.yaml
+++ b/k8s/flipop.floatingippool.crd.yaml
@@ -101,4 +101,3 @@ spec:
     listKind: FloatingIPPoolList
     plural: floatingippools
     singular: floatingippool
-    shortNames: []

--- a/k8s/flipop.rbac.yaml
+++ b/k8s/flipop.rbac.yaml
@@ -28,7 +28,7 @@ rules:
   verbs: ["get", "update", "patch"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
@@ -43,7 +43,7 @@ subjects:
   namespace: flipop
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: flipop

--- a/k8s/kustomization.yml
+++ b/k8s/kustomization.yml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: flipop
+resources:
+  - flipop.nodednsrecordset.crd.yaml
+  - flipop.floatingippool.crd.yaml
+  - flipop.deployment.yaml
+  - flipop.serviceaccount.yaml
+  - flipop.rbac.yaml
+
+


### PR DESCRIPTION
for some definitions an old apiVersion is used which is not not available anymore and leads to errors when applied via kubectl