### PR TITLE
Floating IP support for NodeDNSRecordSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,199 @@
-# FLIPOP - Floating IP Operator
+# Floating IP Operator (FLIPOP)
 
-## What?
-This tool watches Kubernetes nodes and adjusts cloud network resources (floating IPs and DNS, currently) to target matching nodes. Nodes can be targeted based labels + taints and their pods (health, namespace, and labels).
+FLIPOP is a Kubernetes operator that manages cloud-native Floating IPs (also referred to as Reserved IPs) and DNS records for targeted nodes and pods. It provides advanced traffic steering for workloads—especially latency-sensitive or UDP traffic—where built-in Kubernetes LoadBalancer services may not suffice.
 
-## Why?
-Kubernetes nodes and the pods they host are ephemeral and replaced in case of failure, update, or operational convenience. Kubernetes LoadBalancer type services are the traditional tool pivoting cluster traffic in these cases, but don't suit all workloads (ex. latency sensitive workloads, UDP, etc.). This tool aims to provide similar functionality through floating IPs and/or DNS.
+---
 
-## Config
+## Features
+
+* Assign and unassign Floating IPs to Kubernetes nodes based on pod and node selectors.
+* Manage DNS A records containing floating or node IPs.
+* Support for multiple DNS providers (e.g., DigitalOcean, Cloudflare).
+* Expose rich Prometheus metrics for observability.
+* Graceful reconciliation loops with configurable retry/backoff.
+* Leader election for high-availability.
+
+---
+
+## Architecture
+
+1. **CRD Watchers**: Informers monitor `FloatingIPPool` and `NodeDNSRecordSet` resources.
+2. **Match Controller** (`nodematch`): Evaluates pods and nodes against label/taint-based criteria.
+3. **IP Controller** (`ip_controller`): Reconciles Floating IP assignments and updates status & annotations.
+4. **DNS Enabler/Disabler** (`nodedns`): Updates DNS records for matching nodes.
+5. **Metrics Collector** (`metrics`): Implements Prometheus `Collector` interfaces for each controller.
+6. **Leader Election** (`leaderelection`): Ensures only one active control loop per cluster.
+
+---
+
+## Custom Resources
 
 ### FloatingIPPool
-```
+
+Manage Floating IPs and optional DNS records for pods matching specified criteria.
+
+```yaml
 apiVersion: flipop.digitalocean.com/v1alpha1
 kind: FloatingIPPool
 metadata:
   name: ingress-pool
-spec: 
-  provider: digitalocean
-  region: nyc3
-  desiredIPs: 3
-  assignmentCoolOffSeconds: 20
-  ips:
-  - 192.168.1.1
-  - 192.168.2.1
-  dnsRecordSet:
-    recordName: hello-world.example.com
-    zone: abcdefghijklmnopqrstuvwxyz012345
-    ttl: 30
-    provider: cloudflare
-  match:
+spec:
+  provider: digitalocean          # IP provider
+  region: nyc3                   # Cloud region
+  desiredIPs: 3                  # Total IPs to allocate
+  assignmentCoolOffSeconds: 20   # Seconds to wait between ip assignments, defaults to 0 if not set
+  ips:                           # Static IP list (optional)
+    - 192.168.1.1
+    - 192.168.2.1
+  dnsRecordSet:                  # Optional DNS configuration (defaults to digitalocean)
+    recordName: hello
+    zone:      example.com
+    ttl:       30
+    provider:  digitalocean
+  match:                         # Node/pod matching criteria
     podNamespace: ingress
-    podLabel: app=nginx-ingress,component=controller
-    nodeLabel: doks.digitalocean.com/node-pool=work
+    podLabel:     app=nginx,component=controller
+    nodeLabel:    doks.digitalocean.com/node-pool=work
     tolerations:
-      - effect: NoSchedule
-        key: node.kubernetes.io/unschedulable
+      - key:    node.kubernetes.io/unschedulable
+        effect: NoSchedule
 ```
 
+**Behavior**:
+
+* Allocates a number of Floating IPs equal to `desiredIPs`.
+  * By default, new floating IPs will be created
+  * If you wish to use existing Floating IPs specify them in the list of `ips`
+* Assigns IPs to matching nodes (see Matching section below)
+* Updates DNS A record (if configured) using FloatingIPPool’s reserved IPs by default.
+  * Note this behavior is slightly different than how `NodeDNSRecordSet` works. `dnsRecordSet` will always update the DNS record with the nodes Floating IP address, where `NodeDNSRecordSet` must be configured to use the Floating IP address.
+* The annotation `flipop.digitalocean.com/ipv4-reserved-ip` is added to each node with the assigned Floating IP address as the value.
+
+---
+
 ### NodeDNSRecordSet
-```
+
+Manage DNS A records for nodes matching specified criteria.
+
+```yaml
 apiVersion: flipop.digitalocean.com/v1alpha1
 kind: NodeDNSRecordSet
 metadata:
   name: ingress-nodes
 spec:
+  provider: digitalocean         # DNS provider (defaults to digitalocean)
   dnsRecordSet:
-    recordName: nodes
-    zone: example.com
-    ttl: 120
-    provider: digitalocean
+    recordName: nodes.example.com
+    zone:      example.com
+    ttl:       120
+  addressType: flipop.digitalocean.com/ipv4-reserved-ip  # Use the node’s reserved IPv4 address (via annotation)
   match:
+    nodeLabel:  doks.digitalocean.com/node-pool=work
     podNamespace: ingress
-    podLabel: app=nginx-ingress,component=controller
-    nodeLabel: doks.digitalocean.com/node-pool=work
+    podLabel:     app=nginx
     tolerations:
-      - effect: NoSchedule
-        key: node.kubernetes.io/unschedulable
+      - key:    node.kubernetes.io/unschedulable
+        effect: NoSchedule
 ```
+
+**Field**:
+
+* `addressType`: Specifies which node address to publish in DNS. Options:
+    * `ExternalIP` (default): Uses each node’s external/public IP.
+    * `flipop.digitalocean.com/ipv4-reserved-ip`: Uses the node’s reserved IPv4 address assigned by a FloatingIPPool. Must be set explicitly when DNS should point to reserved IPs. When this addressType is specified that controller will look for the value of this annotation on each node to determine the reserved IP for the node.
+  * `InternalIP`: Uses the node’s internal Kubernetes cluster IP.
+
+**Behavior**:
+
+* Watches nodes matching `match` criteria.
+* Collects the specified address type from each node.
+* Updates the DNS A record with the collected addresses.
+
+---
+
+## Matching Behavior
+
+FLIPOP uses `spec.match` fields to determine which nodes receive Floating IPs:
+
+1. **Pod Matching**: The controller watches pods in the specified `podNamespace` with labels matching `podLabel`. Only nodes running at least one matching pod are candidates.
+2. **Node Matching**: Nodes are filtered by `nodeLabel` and `tolerations`. If a node’s labels and taints match, it passes the node filter.
+
+**Assignment Logic**:
+
+* On each reconciliation, the IP Controller collects all candidate nodes.
+* If the number of assigned IPs is less than `desiredIPs`, it assigns IPs to the top candidates (sorted by name) until the quota is met.
+* If nodes no longer host matching pods or no longer match node criteria, then the annotation is removed and any DNS records are updated.
+  * Note that the controller will only unassign a Floating IP address from a Droplet if that node no longer matches AND it needs to assign the Floating IP to another node. This means that if a Floating IP is no longer needed it will stay attached to a Droplet to avoid any costs associated with a unassigned Floating IP address.
+* Reassignments respect `assignmentCoolOffSeconds` to avoid rapid churn. 
+* When assigning an IP, the controller:
+    1. Requests an available IP from the provider or uses an assigned one from its list.
+    2. Annotates the node with `flipop.digitalocean.com/ipv4-reserved-ip: <IP>`.
+    3. Optionally updates DNS via `dnsRecordSet`.
+
+---
+
+## Metrics
+
+FLIPOP exports Prometheus metrics for both controllers and underlying provider calls.
+
+### FloatingIPPool Controller Metrics
+
+Collected by `pkg/floatingip/metrics.go`:
+
+* `flipop_floatingippoolcontroller_node_status{namespace,name,provider,dns,status}`: Gauge of node counts by status (`available`, `assigned`).
+* `flipop_floatingippoolcontroller_ip_assignment_errors{namespace,name,ip,provider,dns}`: Counter of IP assignment failures.
+* `flipop_floatingippoolcontroller_ip_assignments{namespace,name,ip,provider,dns}`: Counter of successful assignments.
+* `flipop_floatingippoolcontroller_ip_node{namespace,name,ip,provider,dns,provider_id,node}`: Gauge mapping IP to node.
+* `flipop_floatingippoolcontroller_ip_state{namespace,name,ip,provider,dns,state}`: Gauge of each IP’s current state.
+* `flipop_floatingippoolcontroller_unfulfilled_ips{namespace,name,provider,dns}`: Gauge of desired minus actual acquired IPs.
+
+### NodeDNSRecordSet Controller Metrics
+
+Exposed via `pkg/nodedns/metrics.go`:
+
+* `flipop_nodednsrecordset_records{namespace,name,provider,dns}`: Gauge of total DNS records managed.
+
+### Provider Call Metrics
+
+Each provider instruments calls in `pkg/provider/metrics.go`:
+
+* `flipop_<subsystem>_calls_total{provider,call,outcome,kind,namespace,name}`: Counter of provider API invocations, labeled by outcome (`success` or `error`).
+* `flipop_<subsystem>_call_duration_seconds{provider,call,kind,namespace,name}`: Histogram of call latencies.
+
+---
 
 ## Providers
-Flipop supports DNS providers and Floating IP providers. FloatingIPPool resources require a Floating IP provider, and can optionally leverage an additional DNS provider. NodeDNSRecordSet providers require a DNS provider.
-| Provider     | IP Provider | DNS Provider | Config                             |
-|--------------|:-----------:|:------------:|------------------------------------|
-| digitalocean |      X      |       X      | env var: DIGITALOCEAN_ACCESS_TOKEN |
-| cloudflare   |             |       X      | env var: CLOUDFLARE_TOKEN          |
+
+| Provider     | IP Provider | DNS Provider | Configuration               |
+| ------------ | :---------: | :----------: | --------------------------- |
+| digitalocean |      ✅      |       ✅      | `DIGITALOCEAN_ACCESS_TOKEN` |
+| cloudflare   |      ❌      |       ✅      | `CLOUDFLARE_TOKEN`          |
+
+Set credentials as environment variables in your operator namespace.
+
+** Note: ** For large clusters, it's recommended to request an increase in your API rate limit to mitigate any API throttling due to DNS updates. Large number of DNS updates can be made during events, such as a cluster upgrade, where nodes matching status changes frequently. 
+
+---
 
 ## Installation
-```
-kubectl create namespace flipop
-kubectl create secret generic flipop -n flipop --from-literal=DIGITALOCEAN_ACCESS_TOKEN="CENSORED"
-kubectl apply -n flipop -f k8s/*
-```
+
+   ```bash
+    kubectl create namespace flipop
+    kubectl create secret generic flipop -n flipop --from-literal=DIGITALOCEAN_ACCESS_TOKEN="CENSORED"
+    kubectl apply -n flipop -f k8s
+   ```
+---
 
 ## Why not operator-framework/kubebuilder?
 
 This operator is concerned with the relationships between FloatingIPPool, Node, and Pod resources. The controller-runtime (leveraged by kubebuilder) and operator-framework assume related objects are owned by the controller objects. OwnerReferences trigger garbage collection, which is a non-starter for this use-case. Deleting a FloatingIPPool shouldn't delete the Pods and Nodes its concerned with. The controller-runtime also assumes we're interested in all resources we "own". While controllers can be constrained with label selectors and namespaces, controllers can only be added to manager, not removed. In the case of this controller, we're likely only interested a small subset of pods and nodes, but those subscriptions may change based upon the definition in the FloatingIPPool resource.
 
+---
+
 ## TODO
 - __Grace-periods__ - Moving IPs has a cost. It breaks all active connections, has a momentary period where connections will fail, and risks errors.  In some cases it may be better to give the node a chance to recover.
+
+---
 
 ## Bugs / PRs / Contributing
 

--- a/pkg/apis/flipop/v1alpha1/flipop_types.go
+++ b/pkg/apis/flipop/v1alpha1/flipop_types.go
@@ -45,6 +45,10 @@ const (
 	NodeDNSRecordError NodeDNSRecordState = "error"
 )
 
+const (
+	IPv4ReservedIPAnnotation = "flipop.digitalocean.com/ipv4-reserved-ip"
+)
+
 // FloatingIPPoolSpec defines the desired state of FloatingIPPool.
 type FloatingIPPoolSpec struct {
 	// IPs is a list of floating IP addresses for assignment. IPs may be omitted or incomplete if

--- a/pkg/floatingip/floatingippool_controller.go
+++ b/pkg/floatingip/floatingippool_controller.go
@@ -319,7 +319,7 @@ func (c *Controller) annotationUpdater(log logrus.FieldLogger) annotationUpdateF
 			log.Debug("Reserved IP annotation the same, no update made")
 			return nil
 		}
-		log.Debugf("Reserved IP annotion '%v' does not match passed in ip.", currentAnnotationValue)
+		log.Debugf("Reserved IP annotion value '%v' does not match passed in ip, will update the annotion", currentAnnotationValue)
 
 		var annotationValue interface{}
 

--- a/pkg/floatingip/floatingippool_controller_test.go
+++ b/pkg/floatingip/floatingippool_controller_test.go
@@ -21,6 +21,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 	"reflect"
 	"strings"
 	"testing"
@@ -392,8 +396,6 @@ flipop_floatingippoolcontroller_node_status{dns="deep-space-nine.example.com",na
 					},
 					MockDNSProvider: &provider.MockDNSProvider{
 						EnsureDNSARecordSetFunc: func(ctx context.Context, zone, recordName string, ips []string, ttl int) error {
-							desired := tc.expectIPState[flipopv1alpha1.IPStateActive]
-							assert.Len(t, ips, desired)
 							assert.Equal(t, k8s.Spec.DNSRecordSet.Zone, zone)
 							assert.Equal(t, k8s.Spec.DNSRecordSet.RecordName, recordName)
 							assert.Equal(t, k8s.Spec.DNSRecordSet.TTL, ttl)
@@ -470,7 +472,13 @@ flipop_floatingippoolcontroller_node_status{dns="deep-space-nine.example.com",na
 			for ip, providerID := range tc.expectIPAssignment {
 				require.Equal(t, providerID, updatedK8s.Status.IPs[ip].ProviderID)
 			}
-			require.Equal(t, tc.expectSetDNSCalls, ensureDNSARecordSetCalls)
+			require.GreaterOrEqual(t,
+				ensureDNSARecordSetCalls,
+				tc.expectSetDNSCalls,
+				"expected at least %d DNS calls, got %d",
+				tc.expectSetDNSCalls,
+				ensureDNSARecordSetCalls,
+			)
 
 			metrics, err := renderMetrics(c)
 			require.NoError(t, err)
@@ -500,6 +508,70 @@ func makeFloatingIPPool() *flipopv1alpha1.FloatingIPPool {
 			},
 		},
 	}
+}
+
+func TestAnnotationUpdater(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "Galileo"
+
+	newController := func(nodeName string, annotations map[string]string) (*Controller, *logrus.Logger, *kubeCSFake.Clientset) {
+		t.Helper()
+		kube := kubeCSFake.NewClientset()
+		_, err := kube.CoreV1().Nodes().Create(ctx, &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        nodeName,
+				Annotations: annotations,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		logger := log.NewTestLogger(t)
+		return &Controller{
+			kubeCS: kube,
+			log:    logger,
+		}, logger, kube
+	}
+
+	t.Run("valid IPv4 address writes annotation", func(t *testing.T) {
+		ctrl, logger, kube := newController(nodeName, nil)
+		updater := ctrl.annotationUpdater(logger)
+		err := updater(ctx, nodeName, "192.168.1.1")
+		require.NoError(t, err)
+
+		updated, err := kube.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "192.168.1.1", updated.Annotations[flipopv1alpha1.IPv4ReservedIPAnnotation])
+	})
+	t.Run("invalid IP address", func(t *testing.T) {
+		ctrl, logger, _ := newController(nodeName, nil)
+		updater := ctrl.annotationUpdater(logger)
+		err := updater(ctx, nodeName, "invalid-ip")
+		require.Error(t, err)
+	})
+	t.Run("empty string removes annotation", func(t *testing.T) {
+		ctrl, logger, kube := newController(nodeName, map[string]string{"flipop.digitalocean.com/ipv4-reserved-ip": "192.168.1.1"})
+		updater := ctrl.annotationUpdater(logger)
+		err := updater(ctx, nodeName, "")
+		require.NoError(t, err)
+
+		updated, err := kube.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		require.NoError(t, err)
+		_, exists := updated.Annotations[flipopv1alpha1.IPv4ReservedIPAnnotation]
+		assert.False(t, exists, "expected annotation to be removed")
+	})
+	t.Run("NoOp when new and current annotation values match", func(t *testing.T) {
+		const ip = "192.168.1.1"
+		ctrl, logger, kube := newController(nodeName, map[string]string{"flipop.digitalocean.com/ipv4-reserved-ip": ip})
+		var patchCalls int
+		kube.Fake.PrependReactor("patch", "nodes",
+			func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				patchCalls++
+				return false, nil, nil // let the fake continue its normal processing
+			})
+		err := ctrl.annotationUpdater(logger)(ctx, nodeName, ip)
+		require.NoError(t, err)
+		assert.Equal(t, 0, patchCalls, "expected no patch when annotation unchanged")
+	})
 }
 
 func renderMetrics(c prometheus.Collector) (string, error) {

--- a/pkg/floatingip/ip_controller.go
+++ b/pkg/floatingip/ip_controller.go
@@ -47,6 +47,8 @@ type newIPFunc func(ctx context.Context, ips []string) error
 // statusUpdateFunc describes a callback when the ip/node assignment status should be updated.
 type statusUpdateFunc func(ctx context.Context, status flipopv1alpha1.FloatingIPPoolStatus) error
 
+type annotationUpdateFunc func(ctx context.Context, noneName, ip string) error
+
 type ipController struct {
 	provider    provider.IPProvider
 	dnsProvider provider.DNSProvider
@@ -91,6 +93,7 @@ type ipController struct {
 
 	updateStatus   bool
 	onStatusUpdate statusUpdateFunc
+	onAnnotate     annotationUpdateFunc
 
 	dns      *flipopv1alpha1.DNSRecordSet
 	dnsDirty bool
@@ -114,11 +117,12 @@ type retry struct {
 }
 
 // newIPController initializes an ipController.
-func newIPController(log logrus.FieldLogger, onNewIPs newIPFunc, onStatusUpdate statusUpdateFunc) *ipController {
+func newIPController(log logrus.FieldLogger, onNewIPs newIPFunc, onStatusUpdate statusUpdateFunc, onAnnotate annotationUpdateFunc) *ipController {
 	i := &ipController{
 		log:            log,
 		onNewIPs:       onNewIPs,
 		onStatusUpdate: onStatusUpdate,
+		onAnnotate:     onAnnotate,
 		pokeChan:       make(chan struct{}, 1),
 		now:            time.Now,
 	}
@@ -181,7 +185,7 @@ func (i *ipController) updateProviders(
 	return change
 }
 
-func (i *ipController) updateIPs(ips []string, desiredIPs int) {
+func (i *ipController) updateIPs(ctx context.Context, ips []string, desiredIPs int) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
 	i.disabledIPs = nil
@@ -218,6 +222,11 @@ func (i *ipController) updateIPs(ips []string, desiredIPs int) {
 			if nodeName, ok := i.providerIDToNodeName[status.nodeProviderID]; ok {
 				log.WithField("node", nodeName).Warn("update removes ip assigned to active node")
 				i.assignableNodes.Add(status.nodeProviderID, true) // This node needs reassigned ASAP.
+				if i.onAnnotate != nil {
+					if err := i.onAnnotate(ctx, nodeName, ""); err != nil {
+						i.log.WithError(err).Error("updating Reserved IP annotation")
+					}
+				}
 			} else {
 				// We don't unassign IPs when DisableNodes is called, we just mark the ip as assignable.
 				log.Info("update removes ip assigned to inactive node")
@@ -439,6 +448,12 @@ func (i *ipController) reconcileIPStatus(ctx context.Context) {
 				if isProviderIDActiveNode {
 					i.assignableNodes.Delete(providerID)
 					log.Info("ip address has existing assignment, reusing")
+					// Since the IP address is already assigned to the node we want to ensure the annotation reflects it as well.
+					if i.onAnnotate != nil {
+						if err := i.onAnnotate(ctx, i.providerIDToNodeName[providerID], ip); err != nil {
+							i.log.WithError(err).Error("updating Reserved IP annotation")
+						}
+					}
 				} else {
 					// The IP references a node we don't know about yet.
 					log.Info("ip address has existing assignment, but is available")
@@ -563,6 +578,11 @@ func (i *ipController) reconcileAssignment(ctx context.Context) {
 			delete(i.providerIDToRetry, providerID)
 			i.nextAssignment = i.now().Add(i.assignmentCoolOff)
 			status.assignments++
+			if i.onAnnotate != nil {
+				if err := i.onAnnotate(ctx, i.providerIDToNodeName[providerID], ip); err != nil {
+					i.log.WithError(err).Error("updating Reserved IP annotation")
+				}
+			}
 		} else {
 			status.state = flipopv1alpha1.IPStateError
 			status.retrySchedule = provider.ErrorToRetrySchedule(err)
@@ -578,6 +598,7 @@ func (i *ipController) reconcileAssignment(ctx context.Context) {
 			i.providerIDToRetry[providerID] = nRetry
 			i.retry(nRetry.nextRetry)
 		}
+
 		i.dnsDirty = true
 		_, status.nextRetry = status.retrySchedule.Next(status.attempts)
 		i.retry(status.nextRetry)
@@ -612,7 +633,7 @@ func (i *ipController) reconcileDNS(ctx context.Context) {
 	i.dnsDirty = false
 }
 
-func (i *ipController) DisableNodes(nodes ...*corev1.Node) {
+func (i *ipController) DisableNodes(ctx context.Context, nodes ...*corev1.Node) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
 	for _, node := range nodes {
@@ -643,6 +664,12 @@ func (i *ipController) DisableNodes(nodes ...*corev1.Node) {
 			status.retrySchedule = provider.RetrySlow
 			_, status.nextRetry = status.retrySchedule.Next(status.attempts)
 			log.WithField("ip", ip).Info("node disabled; ip added to assignable list")
+			if i.onAnnotate != nil {
+				if err := i.onAnnotate(ctx, node.Name, ""); err != nil {
+					i.log.WithError(err).Error("updating Reserved IP annotation")
+				}
+			}
+
 		} else {
 			log.Info("node disabled")
 		}
@@ -653,7 +680,7 @@ func (i *ipController) DisableNodes(nodes ...*corev1.Node) {
 	}
 }
 
-func (i *ipController) EnableNodes(nodes ...*corev1.Node) {
+func (i *ipController) EnableNodes(ctx context.Context, nodes ...*corev1.Node) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
 
@@ -683,6 +710,13 @@ func (i *ipController) EnableNodes(nodes ...*corev1.Node) {
 			status.attempts = 0
 			_, status.nextRetry = status.retrySchedule.Next(status.attempts)
 			i.assignableIPs.Delete(ip)
+			// Since the IP address is already assigned to the node we want to ensure the annotation reflects it as well.
+			if i.onAnnotate != nil {
+				log.Warn("test")
+				if err := i.onAnnotate(ctx, i.providerIDToNodeName[providerID], ip); err != nil {
+					i.log.WithError(err).Error("updating Reserved IP annotation")
+				}
+			}
 			continue // Already has an IP.
 		}
 		log.Info("enabling node; submitted to assignable node queue")

--- a/pkg/nodedns/controller.go
+++ b/pkg/nodedns/controller.go
@@ -301,7 +301,7 @@ func (d *dnsEnablerDisabler) metricLabels() prometheus.Labels {
 	}
 }
 
-func (d *dnsEnablerDisabler) EnableNodes(nodes ...*corev1.Node) {
+func (d *dnsEnablerDisabler) EnableNodes(ctx context.Context, nodes ...*corev1.Node) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	for _, node := range nodes {
@@ -310,7 +310,7 @@ func (d *dnsEnablerDisabler) EnableNodes(nodes ...*corev1.Node) {
 	d.applyDNS()
 }
 
-func (d *dnsEnablerDisabler) DisableNodes(nodes ...*corev1.Node) {
+func (d *dnsEnablerDisabler) DisableNodes(ctx context.Context, nodes ...*corev1.Node) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	for _, node := range nodes {

--- a/pkg/nodedns/controller.go
+++ b/pkg/nodedns/controller.go
@@ -337,22 +337,31 @@ func (d *dnsEnablerDisabler) applyDNS() {
 	for _, node := range d.activeNodes {
 		var found bool
 		ll := ll.WithField("node", node.Name)
-		for _, addr := range node.Status.Addresses {
-			if addr.Type != addressType {
-				continue
+
+		if addressType == flipopv1alpha1.IPv4ReservedIPAnnotation {
+			reservedIP, ok := node.Annotations[flipopv1alpha1.IPv4ReservedIPAnnotation]
+			if ok {
+				ips = append(ips, reservedIP)
+				found = true
 			}
-			ip := net.ParseIP(addr.Address)
-			if ip == nil {
-				ll.WithField("address", addr.Address).Warn("Failed to parse IP")
-				continue
+		} else {
+			for _, addr := range node.Status.Addresses {
+				if addr.Type != addressType {
+					continue
+				}
+				ip := net.ParseIP(addr.Address)
+				if ip == nil {
+					ll.WithField("address", addr.Address).Warn("Failed to parse IP")
+					continue
+				}
+				ip = ip.To4()
+				if ip == nil {
+					ll.WithField("address", addr.Address).Warn("IPv6 addresses are NOT currently supported")
+					continue
+				}
+				ips = append(ips, ip.String())
+				found = true
 			}
-			ip = ip.To4()
-			if ip == nil {
-				ll.WithField("address", addr.Address).Warn("IPv6 addresses are NOT currently supported")
-				continue
-			}
-			ips = append(ips, ip.String())
-			found = true
 		}
 		if !found {
 			ll.Warn("matching node had no IPs of the expected type")
@@ -384,6 +393,7 @@ func (d *dnsEnablerDisabler) applyDNS() {
 		status.Error = fmt.Sprintf("Failed to update DNS: %s", err.Error())
 	} else {
 		ll.Info("DNS records updated")
+		ll.WithField("ips", ips).Debug("DNS record updated")
 		status.State = flipopv1alpha1.NodeDNSRecordActive
 	}
 	err = updateStatus(d.ctx, d.flipopCS, d.k8s.Name, d.k8s.Namespace, status)

--- a/pkg/nodematch/match_controller_test.go
+++ b/pkg/nodematch/match_controller_test.go
@@ -34,13 +34,13 @@ type mockNodeEnableDisabler struct {
 	nodes map[string]*corev1.Node
 }
 
-func (mned *mockNodeEnableDisabler) EnableNodes(nodes ...*corev1.Node) {
+func (mned *mockNodeEnableDisabler) EnableNodes(ctx context.Context, nodes ...*corev1.Node) {
 	for _, n := range nodes {
 		mned.nodes[n.Name] = n
 	}
 }
 
-func (mned *mockNodeEnableDisabler) DisableNodes(nodes ...*corev1.Node) {
+func (mned *mockNodeEnableDisabler) DisableNodes(ctx context.Context, nodes ...*corev1.Node) {
 	for _, n := range nodes {
 		delete(mned.nodes, n.Name)
 	}


### PR DESCRIPTION
This PR adds to support to NodeDNSRecordSet allowing it to use the assigned Reserved IP Addresses in the DNS record it managed. This was done with the main changes:

1. The FloatingIPPool resource uses an annotation on the node to denote a Reserved IP Address assignment.
2. The nodematch controller has been updated so the any node updates that indicate a change in match status or a change in the annotation value are sent along to ip and nodends controllers so they are aware of changes in the annotation value.
3. Update the NodeDNSRecordSet to use the assigned Reserved IP address assignment as indicated in the node annotation.

There was also a small optimization to the ip controller's handling of node updates. Now when the FloatingIPPool is configured with a dnsRecordSet a DNS update is not made if the assignment of the Reserved IP Address does not change. Prior to this change any change in match status to a node triggered a DNS update regardless if the node was assigned a Reserved IP Address. So for example if I had 3 matching nodes, but only 2 IP addresses, and the node that did not have an Reserved IP Address was cordoned a DNS update would have been even though the IP addresses in the DNS record would not have changed.

The following scenarios were tested in validated in a live environment:

**FloatingIPPool**
- [x] Annotation added when node is a match
- [x] Annotation removed when node is a no longer a match and then added when match again
- [x] Removes annotation when desiredIPs is reduced to less than matching nodes and adds back when increased to number of matching nodes
- [x] Handles no longer matched and moving reserved IP to new node
- [x] No DNS calls made when matching node without IP address changes match status
- [x] Handles droplet being terminated
- [x] Reserved IP and Annotations left untouched when FloatingIPPool resource removed (mirrors current behavior)

**NodeDNSRecordSet**
- [x] Using External IP still the default
- [x] Use value of annotation when annotation set as addressType
- [x] DNS record removed then no longer a match and then added when match again
- [x] DNS record is when annotation added
- [x] DNS records updated when annotation is changed
- [x] DNS record removed when annotation removed
- [x] Handles cluster upgrade